### PR TITLE
Adds Google Api logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 config.json
 node_modules
+
+*secrets

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -2,12 +2,14 @@
 
 var Passwords = require('./validators/passwords.js');
 var TaxForm = require('./validators/tax_form.js');
+var HomeTown = require('./validators/home_town.js');
 var Validator = require('./validators/validator.js');
 
 function Validators(config) {
     return [
         new Passwords(config.passwords),
         new TaxForm(),
+	new HomeTown(),
         new Validator({}), // Default
     ];
 }

--- a/lib/validators/google_request.js
+++ b/lib/validators/google_request.js
@@ -1,0 +1,39 @@
+var underscore = require('underscore');
+var https = require('https');
+var fs = require('fs');
+
+function GoogleAddressApi(prototype) {
+    return underscore.extend(underscore.clone(GoogleAddressApi.prototype), prototype);
+};
+
+GoogleAddressApi.prototype = {
+	getAddress: function(home_town, return_func) {
+		var encoded_home_town = encodeURI(home_town.trim());
+		var api_key = fs.readFileSync('secrets').toString().trim();
+		var options = {
+		    host: 'maps.googleapis.com',
+		    path: '/maps/api/place/autocomplete/json?key=' + api_key + '&types=(cities)&input=' + encoded_home_town,
+		    method: 'GET',
+		    port: 443
+		};
+		var callback = function(response) {
+		    var response_string = '';
+		    response.on('data', function(chunk) {
+		      response_string += chunk;
+		    });
+
+		    response.on('end', function() {
+		      var parsedJson = JSON.parse(response_string),
+			  predictions = parsedJson.predictions,
+			  count = predictions.length;
+
+		      return_func(predictions, count);
+		    });
+		},
+	        var req = https.request(options, callback);
+	        req.end();
+        },
+	getNothing: "hello"
+};
+
+module.exports = GoogleAddressApi;

--- a/lib/validators/home_town.js
+++ b/lib/validators/home_town.js
@@ -40,8 +40,9 @@ HomeTown.prototype = new Validator({
     canValidate: function (message) {
         var home_town = message,
             // Valid input is alpha, spaces and ','
-            valid_chars = /^[A-Za-z\s,]+$/;
-        return home_town.match(valid_chars);
+            valid_chars = /^[A-Za-z\s,]+$/,
+	    valid_number = /^\d+$/;
+        return home_town.match(valid_chars) || home_town.match(valid_number);
     },
     get: function (message, prop) {
         return this.config[prop];

--- a/lib/validators/home_town.js
+++ b/lib/validators/home_town.js
@@ -28,7 +28,7 @@ HomeTown.prototype = new Validator({
 		var options = "I found a few places with that name. Which is yours?";
 		for (var i = 0; i < count; i++) {
 		   options += "\n";
-		   options += (i + 1) + ":" + predictions[i].description;
+		   options += (i + 1) + ":" + locations[i].description;
 		}
 		console.log(options);
 		// TODO: Save options to database with key

--- a/lib/validators/home_town.js
+++ b/lib/validators/home_town.js
@@ -1,0 +1,51 @@
+"use strict";
+
+var Validator = require('./validator.js');
+var GoogleAddressApi = require('./google_request.js');
+
+function HomeTown() {
+    this.config = {
+        success_message: "Welcome to the Haunting.",
+        fail_message: ""
+    };
+}
+
+HomeTown.prototype = new Validator({
+    isValid: function (message, from_raw) {
+        var from = this.clean_number(from_raw),
+	    // don't clean the message
+            home_town = message;
+            
+            GoogleAddressApi.getAddresses(home_town, function(locations, count) {
+	      if (count === 0) {
+		console.log("No place with that name exists.");
+	      }
+	      else if (count === 1) {
+		console.log("Welcome to the haunting, former occupant of " + locations[0].description);
+		// TODO: save answer to the database with key
+	      }
+	      else {
+		var options = "I found a few places with that name. Which is yours?";
+		for (var i = 0; i < count; i++) {
+		   options += "\n";
+		   options += (i + 1) + ":" + predictions[i].description;
+		}
+		console.log(options);
+		// TODO: Save options to database with key
+	      }
+	    );
+	// help, how do you return something that's callback dependent??
+        return true;
+    },
+    canValidate: function (message) {
+        var home_town = message,
+            // Valid input is alpha, spaces and ','
+            valid_chars = /^[A-Za-z\s,]+$/;
+        return home_town.match(valid_chars);
+    },
+    get: function (message, prop) {
+        return this.config[prop];
+    },
+});
+
+module.exports = HomeTown;

--- a/lib/validators/locations_database.js
+++ b/lib/validators/locations_database.js
@@ -1,0 +1,29 @@
+var sqlite3 = require('sqlite3').verbose();
+var db = new sqlite3.Database('locations');
+
+db.serialize(function() {
+  db.run("CREATE TABLE guest_hometowns ( tel INTEGER PRIMARY KEY, answer TEXT, options TEXT )");
+});
+  
+
+var saveNumber(number, answer, options) {
+  db.serialize(function() {
+    db.run("INSERT INTO guest_hometowns VALUES ($number, $answer, $options)", {
+      $number: number,
+      $answer: answer,
+      $options: options
+    });
+  });
+}
+
+var fetchNumber(number) {
+  db.serialize(function() {
+    db
+      .prepare("SELECT tel, answer, options FROM guest_hometowns WHERE tel = ?", number)
+      .get(function(err, row) {
+          if (err) throw err;
+          console.log(row.number, + ":" + row.answer + "::" + row.options);
+        }
+      })
+      .finalize();
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "pi-gpio",
     "twilio",
     "underscore",
-    "moment"
+    "moment",
+    "sqlite3"
   ]
 }


### PR DESCRIPTION
This is a rough crack at adding Google Address validation.  I had a lot of trouble getting `npm` packages to install, so I wasn't able to test it out as much as I would have liked to, but hopefully it gets this moving forward.  The Google API stuff works ok, but I couldn't get my attempt at making a Prototype working. Either something's wrong with the syntax or the package manager was having trouble with loading `underscore.`

You'll need a file called `secrets` with the API key saved in the same directory as the `google_request.js` file to make it work.  I'll send it to you via email.  (It's set to be ignored by `.gitignore` so it doesn't get checked in by accident).

Also, the sqlite3 code is untested -- I couldn't get the module to load on either my macbook or raspi.

If you enter in an address that has multiple options, we'd need to be able to save those options, and give you the choice to select which one you meant.

When a number texts in an answer, you first would query the database to find if a record existed for it.  If it's not in the database yet, then we'd fetch the results for the message using the `GoogleAddressApi` class thing.

If there's one entry for your query, we save that in the database as the `answer` and let you in.

If there's more than one entry for the query, we'd present them with a list of numbered options, and also save the options as an array in `options`.  Once they texted back, we'd be able to look them up in the database, see that there's already an entry for them, and then pick the correct option out to echo back. (and save it to the answers column).

Sorry I suck so hard at package management, there's still a decent amount left to do on the database portion.  I'll email you the secrets file, and hopefully we can take a look at it sometime this week.
